### PR TITLE
Type alias `MyHeaders` in tutorial corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ type API =
     :> GetPartialContent '[JSON] (Headers MyHeaders [Color])
 
 type MyHeaders =
-  Header "Total-Count" Int :> PageHeaders '["name"] Color
+  Header "Total-Count" Int ': PageHeaders '["name"] Color
 ```
 
 `PageHeaders` is a type alias provided by the library to declare the necessary response headers


### PR DESCRIPTION
Did not compile. Does now, and works! In the examples it's already correct.

Thank you for this awesome library!