### PR TITLE
Url encode values to fix parsing/unparsing of Range headers with strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2.0 (2018-11-14)
+
+- Use URL encoding for range values to properly support strings.
+
 ## v2.1.3 (2018-11-14)
 
 - Fix Haddock generation

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Therefore, client can provide a `Range` header with their request with the follo
 
 - `Range: <field> [<value>][; offset <o>][; limit <l>][; order <asc|desc>]`
 
-For example: `Range: createdAt 2017-01-15T23:14:67.000Z; offset 5; order desc` indicates that
+For example: `Range: createdAt 2017-01-15T23%3A14%3A67.000Z; offset 5; order desc` indicates that
 the client is willing to retrieve the next batch of document in descending order that were
 created after the fifteenth of January, skipping the first 5.
 
@@ -26,8 +26,8 @@ response with 3 headers:
 For example:
 
 - `Accept-Ranges: createdAt, modifiedAt`
-- `Content-Range: createdAt 2017-01-15T23:14:51.000Z..2017-02-18T06:10:23.000Z`
-- `Next-Range: createdAt 2017-02-19T12:56:28.000Z; offset 0; limit 100; order desc`
+- `Content-Range: createdAt 2017-01-15T23%3A14%3A51.000Z..2017-02-18T06%3A10%3A23.000Z`
+- `Next-Range: createdAt 2017-02-19T12%3A56%3A28.000Z; offset 0; limit 100; order desc`
 
 
 ## Getting Started

--- a/servant-pagination.cabal
+++ b/servant-pagination.cabal
@@ -10,7 +10,7 @@ description:
     different fashions (pagination with offset / limit, endless scroll using
     last referenced resources, ascending and descending ordering, etc.)
 version:
-    2.1.3
+    2.2.0
 homepage:
     https://github.com/chordify/haskell-servant-pagination
 bug-reports:
@@ -89,6 +89,7 @@ library
     , servant >= 0.11 && < 0.16
     , servant-server >= 0.11 && < 0.16
     , safe >= 0.3 && < 1
+    , uri-encode >= 1.5 && < 1.6
 
   hs-source-dirs:
     src

--- a/src/Servant/Pagination.hs
+++ b/src/Servant/Pagination.hs
@@ -117,6 +117,7 @@ import           Data.Maybe     (listToMaybe)
 import           Data.Proxy     (Proxy (..))
 import           Data.Semigroup ((<>))
 import           Data.Text      (Text)
+import           Network.URI.Encode (encodeText,decodeText)
 import           GHC.Generics   (Generic)
 import           GHC.TypeLits   (KnownSymbol, Symbol, symbolVal)
 import           Servant
@@ -249,7 +250,7 @@ instance ToHttpApiData (Ranges fields resource) where
 
   toUrlPiece (Ranges Range{..}) =
     Text.pack (symbolVal rangeField)
-    <> maybe "" (\v -> " " <> toUrlPiece v) rangeValue
+    <> maybe "" (\v -> " " <> (encodeText . toUrlPiece) v) rangeValue
     <> ";limit "  <> toUrlPiece rangeLimit
     <> ";offset " <> toUrlPiece rangeOffset
     <> ";order "  <> toUrlPiece rangeOrder
@@ -284,7 +285,7 @@ instance
             traverse parseOpt rest
 
           range <- Range
-            <$> sequence (fmap parseQueryParam (listToMaybe value))
+            <$> sequence (fmap (parseUrlPiece . decodeText) (listToMaybe value))
             <*> ifOpt "limit"  defaultRangeLimit opts
             <*> ifOpt "offset" defaultRangeOffset opts
             <*> ifOpt "order"  defaultRangeOrder opts
@@ -367,7 +368,7 @@ data ContentRange (fields :: [Symbol]) resource =
 
 instance ToHttpApiData (ContentRange fields res) where
   toUrlPiece (ContentRange start end field) =
-    Text.pack (symbolVal field) <> " " <> toUrlPiece start <> ".." <> toUrlPiece end
+    Text.pack (symbolVal field) <> " " <> (encodeText . toUrlPiece) start <> ".." <> (encodeText . toUrlPiece) end
 
 
 --


### PR DESCRIPTION
When using this library with a range type of `String` (or `Text` actually), the returned `Next-Range` header is not correctly encoded and when passed back is not correctly parsed.

This merge requests url encodes the value, so that it can be correctly parsed again.