### PR TITLE
Bump servant bounds

### DIFF
--- a/servant-pagination.cabal
+++ b/servant-pagination.cabal
@@ -84,8 +84,8 @@ library
   build-depends:
       base >= 4 && < 5
     , text >= 1.2 && < 2
-    , servant >= 0.11 && < 0.18
-    , servant-server >= 0.11 && < 0.18
+    , servant >= 0.11 && < 0.19
+    , servant-server >= 0.11 && < 0.19
     , safe >= 0.3 && < 1
     , uri-encode >= 1.5 && < 1.6
 


### PR DESCRIPTION
This should let it compile against latest servant. Seems to work without any changes.