### PR TITLE
Check that limit is non-negative

### DIFF
--- a/servant-pagination.cabal
+++ b/servant-pagination.cabal
@@ -10,7 +10,7 @@ description:
     different fashions (pagination with offset / limit, endless scroll using
     last referenced resources, ascending and descending ordering, etc.)
 version:
-    2.3.0
+    2.4.0
 homepage:
     https://github.com/chordify/haskell-servant-pagination
 bug-reports:

--- a/src/Servant/Pagination.hs
+++ b/src/Servant/Pagination.hs
@@ -289,7 +289,7 @@ instance
 
           range <- Range
             <$> mapM (parseUrlPiece . decodeText) (listToMaybe value)
-            <*> ifOpt "limit"  defaultRangeLimit opts
+            <*> (ifOpt "limit"  defaultRangeLimit opts >>= checkLimit)
             <*> ifOpt "offset" defaultRangeOffset opts
             <*> ifOpt "order"  defaultRangeOrder opts
             <*> pure (Proxy @field)
@@ -312,6 +312,10 @@ instance
       ifOpt opt def =
         maybe (pure def) (parseQueryParam . snd) . find ((== opt) . fst)
 
+      checkLimit :: Int -> Either Text Int
+      checkLimit n
+        | n < 0     = Left "Limit must be non-negative"
+        | otherwise = return n
 
 -- | Define the sorting order of the paginated resources (ascending or descending)
 data RangeOrder


### PR DESCRIPTION
As title, in the current code we allow negative number for the limit parameter, but negative numbers make no sense here, and it may even cause problems upstream (e.g. constructing database calls with `limit -1`), so this PR changes the parser to forbid those.

Obviously we could also choose to make the number of type `Natural`, but since that is not backwards compatible I think enforcing this in the parser is nicer.