### PR TITLE
Don't return Next-Range upon partial response

### DIFF
--- a/src/Servant/Pagination.hs
+++ b/src/Servant/Pagination.hs
@@ -464,7 +464,10 @@ returnRange Range{..} rs = do
             , contentRangeField = rangeField
             }
 
-      return $ addHeader AcceptRanges $ addHeader contentRange $ addHeader nextRange rs
+      let addNextRange | length rs < rangeLimit = noHeader
+                       | otherwise              = addHeader nextRange
+
+      return $ addHeader AcceptRanges $ addHeader contentRange $ addNextRange rs
 
 -- | Default values to apply when parsing a 'Range'
 data RangeOptions  = RangeOptions


### PR DESCRIPTION
This fixes #3, whenever we have less than `limit` items, we can be certain that the end of the list is reached.