### PR TITLE
Expose PutRange so we can use this in integrations

### DIFF
--- a/servant-pagination.cabal
+++ b/servant-pagination.cabal
@@ -10,7 +10,7 @@ description:
     different fashions (pagination with offset / limit, endless scroll using
     last referenced resources, ascending and descending ordering, etc.)
 version:
-    2.4.2
+    2.4.3
 homepage:
     https://github.com/chordify/haskell-servant-pagination
 bug-reports:

--- a/src/Servant/Pagination.hs
+++ b/src/Servant/Pagination.hs
@@ -102,6 +102,7 @@ module Servant.Pagination
   , ContentRange (..)
   , PageHeaders
   , IsRangeType
+  , PutRange
 
   -- * Declare Ranges
   , HasPagination(..)


### PR DESCRIPTION
I'm writing an integration of servant-pagination with my library [beam](https://github.com/haskell-beam/beam). In order to do that, I need to use `PutRange` in constraints so that we can pass around witnesses that fields can be paginated against.

I understand wanting to hide the implementation of `PutRange`, but there's no reason the class itself can't be exposed in order to be able to use it in constraints. Another option would be to place it in an `Internal` module. 

Otherwise, GHC ends up generating user-visible constraints that contain a class we cannot mention, which makes integrating this library difficult.