### PR TITLE
Allow text-2.0 and servant-0.19

### DIFF
--- a/servant-pagination.cabal
+++ b/servant-pagination.cabal
@@ -83,9 +83,9 @@ library
 
   build-depends:
       base >= 4 && < 5
-    , text >= 1.2 && < 2
-    , servant >= 0.11 && < 0.19
-    , servant-server >= 0.11 && < 0.19
+    , text >= 1.2 && < 2.1
+    , servant >= 0.11 && < 0.20
+    , servant-server >= 0.11 && < 0.20
     , safe >= 0.3 && < 1
     , uri-encode >= 1.5 && < 1.6
 


### PR DESCRIPTION
Fixes #19.

The main servant repo has upgraded to version 0.19 (already released) and now allows text-2.0 (released in [a revision](https://hackage.haskell.org/package/servant-server-0.19/revisions/)).

I tested using

     cabal test -w ghc-9.0.2 --constraint='text>=2' --constraint='servant>=0.19' --constraint='servant-server>=0.19'

(which passed).

So I believe this can be merged with no risks or adverse effects!